### PR TITLE
#89 implement user entity method to change name

### DIFF
--- a/tourou/lib/domain/entity/user.dart
+++ b/tourou/lib/domain/entity/user.dart
@@ -4,7 +4,7 @@
 import '../value_object/value_object.dart';
 
 class User {
-  const User({
+  User({
     required this.userId,
     required UserName userName,
     required ProfilePhotoLink profilePhotoLink,

--- a/tourou/lib/domain/entity/user.dart
+++ b/tourou/lib/domain/entity/user.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: use_setters_to_change_properties
+
 // Project imports:
 import '../value_object/value_object.dart';
 
@@ -14,7 +16,7 @@ class User {
         _goodTourous = goodTourous;
 
   final UserId userId;
-  final UserName _userName;
+  UserName _userName;
   final ProfilePhotoLink _profilePhotoLink;
   final List<UserId> _blockedUsers;
   final List<TourouId> _goodTourous;
@@ -39,5 +41,9 @@ class User {
         profilePhotoLink.hashCode ^
         blockedUsers.hashCode ^
         goodTourous.hashCode;
+  }
+
+  void changeUserName(UserName newUserName) {
+    _userName = newUserName;
   }
 }


### PR DESCRIPTION
``ignore_for_file: use_setters_to_change_properties``
は値変更のメソッドをセッター扱いにされてしまう&これに対応すると不要なgetterを用意しなければいけない
なので、採用しています。